### PR TITLE
ci: add smoke test for parse-crates

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,35 @@
+name: smoke-test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  parse-crates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout nu-history-tools
+        uses: actions/checkout@v4
+        with:
+          path: nu-history-tools
+
+      - name: Checkout nushell (sibling, needed by --crates_dir default)
+        uses: actions/checkout@v4
+        with:
+          repository: nushell/nushell
+          path: nushell
+          fetch-depth: 0
+
+      - name: Install Nushell
+        uses: hustcer/setup-nu@v3
+        with:
+          check-latest: true
+
+      - name: Run `toolkit main parse-crates` with default args
+        shell: nu {0}
+        working-directory: nu-history-tools
+        run: |
+          use toolkit.nu
+          toolkit main parse-crates

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   parse-crates:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout nu-history-tools
         uses: actions/checkout@v4
@@ -29,4 +33,5 @@ jobs:
 
       - name: Run `toolkit main parse-crates` with default args
         working-directory: nu-history-tools
+        shell: bash
         run: nu -c 'use toolkit.nu; toolkit main parse-crates'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -28,8 +28,5 @@ jobs:
           check-latest: true
 
       - name: Run `toolkit main parse-crates` with default args
-        shell: nu {0}
         working-directory: nu-history-tools
-        run: |
-          use toolkit.nu
-          toolkit main parse-crates
+        run: nu -c 'use toolkit.nu; toolkit main parse-crates'


### PR DESCRIPTION
A user reported that `use toolkit.nu; toolkit main parse-crates` errored with `set an $output_dir param` even though they had the prerequisite `../nushell` sibling repo in place. The function relies on default paths (`assets/crates_parsing` for output, `../nushell/crates` for input) that must exist on disk, and there was no CI catching cases where the command fails on a clean environment.

The workflow installs the latest Nushell via `hustcer/setup-nu@v3` (`check-latest: true`), checks out `nushell/nushell` as a sibling with full tag history (the script iterates `git tag`), and runs `toolkit main parse-crates` with defaults. Exit 0 means defaults still work end-to-end. "Latest" was chosen over a pinned version, accepting that the CI is non-hermetic but surfaces real breakage from new Nushell releases.